### PR TITLE
增加单元测试用例

### DIFF
--- a/src/test/java/ReFreSH/JMobileSuit/IO/IOServerTests.java
+++ b/src/test/java/ReFreSH/JMobileSuit/IO/IOServerTests.java
@@ -425,6 +425,26 @@ public class IOServerTests {
         assertEquals(1, prefixLengthStack.size());
         assertEquals(Integer.valueOf(10), prefixLengthStack.pop());
     }
+    @Test
+    public void testIOServerConstructorWithSuitConfiguration() {
+
+        PromptServer mockPrompt = mock(PromptServer.class);
+        ColorSetting mockColorSetting = mock(ColorSetting.class);
+        Logger mockLogger = mock(Logger.class);
+
+        SuitConfiguration mockConfig = mock(SuitConfiguration.class);
+        when(mockConfig.Prompt()).thenReturn(mockPrompt);
+        when(mockConfig.ColorSetting()).thenReturn(mockColorSetting);
+        when(mockConfig.Logger()).thenReturn(mockLogger);
+
+        IOServer ioserver = new IOServer(mockConfig);
+
+        assertEquals(mockPrompt, ioserver.Prompt);
+        assertEquals(mockColorSetting, ioserver.ColorSetting);
+        assertEquals(System.in, ioserver.GetInput());
+        assertEquals(System.out, ioserver.Output);
+        assertEquals(System.err, ioserver.Error);
+    }
 
 
 }


### PR DESCRIPTION
增加IOSever的单元测试，提高覆盖率至71%
<img width="620" alt="image" src="https://github.com/user-attachments/assets/3efa4d08-3591-4832-ae60-e8dd2585f1d8" />
